### PR TITLE
Add Microsoft 365 (OneDrive/SharePoint) storage backend and CLI support

### DIFF
--- a/youtube_to_docs/main.py
+++ b/youtube_to_docs/main.py
@@ -14,7 +14,7 @@ from youtube_to_docs.llms import (
     get_model_pricing,
 )
 from youtube_to_docs.models import MODEL_SUITES
-from youtube_to_docs.storage import GoogleDriveStorage, LocalStorage
+from youtube_to_docs.storage import GoogleDriveStorage, LocalStorage, M365Storage
 from youtube_to_docs.transcript import (
     extract_audio,
     fetch_transcript,
@@ -48,7 +48,8 @@ def main(args_list: list[str] | None = None) -> None:
         help=(
             "Can be one of: \n"
             "Local file path to save the output CSV file.\n"
-            "'workspace' or 'w' to store to Google Drive or a workspace folder ID."
+            "'workspace' or 'w' to store to Google Drive or a workspace folder ID.\n"
+            "'sharepoint' to store to Microsoft 365 (OneDrive/SharePoint)."
         ),
     )
     parser.add_argument(
@@ -170,7 +171,12 @@ def main(args_list: list[str] | None = None) -> None:
 
     # Setup Output Directories
     # Setup Storage
-    if outfile in ("workspace", "w") or (
+    if outfile == "sharepoint":
+        print("Using Microsoft 365 storage. Output: sharepoint")
+        storage = M365Storage(outfile)
+        outfile_path = "youtube-docs.csv"
+        base_dir = "."
+    elif outfile in ("workspace", "w") or (
         len(outfile) > 20
         and "." not in outfile
         and "/" not in outfile


### PR DESCRIPTION
### Motivation
- Provide a Microsoft 365 (OneDrive/SharePoint) storage backend mirroring the existing Google Drive storage to support enterprise storage targets.
- Allow the CLI to target OneDrive/SharePoint via a simple output flag so artifacts can be saved outside local or Google Drive storage.
- Support common format needs by converting Markdown to `docx` and CSV to `xlsx` so text and data are friendly in M365.

### Description
- Added `M365Storage` in `youtube_to_docs/storage.py` implementing the `Storage` interface using Microsoft Graph and `msal`, plus helpers for upload/download, folder creation, and caching.
- Implemented file mapping and format conversions using `pypandoc` for Markdown<->DOCX and `polars` for CSV/XLSX, and HTTP calls via `requests` to the Graph API.
- Wired CLI support in `youtube_to_docs/main.py` so `-o sharepoint` selects `M365Storage`, and updated the help text to mention the `sharepoint` option.
- Added supporting imports (`msal`, `pypandoc`, `requests`, `base64`, `mimetypes`) and token cache persistence for interactive/local auth.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957c2b1b60883308b04f3f1363dbd0e)