### PR TITLE
Add Notebooks section and Google Colab notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # youtube-to-docs
 [![PyPI version](https://img.shields.io/pypi/v/youtube-to-docs.svg)](https://pypi.org/project/youtube-to-docs/)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/DoIT-Artificial-Intelligence/youtube-to-docs/blob/main/notebooks/getting_started.ipynb)
 
 Click on the image below to see a demo of YouTube to docs:
 
@@ -49,5 +50,9 @@ Install as a Gemini CLI extension:
 ```bash
 gemini extensions install https://github.com/DoIT-Artificial-Intelligence/youtube-to-docs.git
 ```
+
+### Notebooks
+
+Try out `youtube-to-docs` in your browser with our [Getting Started](https://colab.research.google.com/github/DoIT-Artificial-Intelligence/youtube-to-docs/blob/main/notebooks/getting_started.ipynb) Google Colab notebook.
 
 *Created with the help of AI. All artifacts have been checked and work as expected.*

--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -1,0 +1,15 @@
+# Notebooks
+
+Explore `youtube-to-docs` using interactive Jupyter notebooks.
+
+## Getting Started
+
+This notebook demonstrates the basic usage of the `youtube-to-docs` CLI in a Google Colab environment.
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/DoIT-Artificial-Intelligence/youtube-to-docs/blob/main/notebooks/getting_started.ipynb)
+
+### What's covered:
+- Installation with optional features.
+- Setting up API keys and environment variables.
+- Running the CLI to process videos.
+- Generating infographics and audio summaries.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
   - How It Works: how-this-works.md
   - Performance: performance.md
   - Pricing: pricing.md
+  - Notebooks: notebooks.md
 
 exclude_docs: |
   development.md

--- a/notebooks/getting_started.ipynb
+++ b/notebooks/getting_started.ipynb
@@ -1,0 +1,140 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# YouTube to Docs - Getting Started\n",
+    "\n",
+    "This notebook demonstrates how to use the `youtube-to-docs` tool to convert YouTube videos into structured documentation, including transcripts, summaries, and infographics.\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/DoIT-Artificial-Intelligence/youtube-to-docs/blob/main/notebooks/getting_started.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Installation\n",
+    "\n",
+    "First, we install the `youtube-to-docs` package with the `all` extra to enable all features."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install youtube-to-docs[all]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Setup Environment Variables\n",
+    "\n",
+    "To use the YouTube API and AI models (like Gemini), you'll need to set up your API keys. In Google Colab, you can manage these securely using the 'Secrets' tab (the key icon 🔑 on the left sidebar)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from google.colab import userdata\n",
+    "import os\n",
+    "\n",
+    "# Ensure you have set these in Colab Secrets\n",
+    "try:\n",
+    "    os.environ[\"YOUTUBE_DATA_API_KEY\"] = userdata.get('YOUTUBE_DATA_API_KEY')\n",
+    "    os.environ[\"GEMINI_API_KEY\"] = userdata.get('GEMINI_API_KEY')\n",
+    "    print(\"API keys loaded successfully!\")\n",
+    "except Exception as e:\n",
+    "    print(f\"Error loading API keys: {e}\")\n",
+    "    print(\"Please make sure YOUTUBE_DATA_API_KEY and GEMINI_API_KEY are set in Colab Secrets.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Run youtube-to-docs CLI\n",
+    "\n",
+    "You can now run the `youtube-to-docs` command. Here's a basic example that generates a summary and Q&A for a default video."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!youtube-to-docs -m gemini-2.0-flash"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Advanced Features\n",
+    "\n",
+    "You can also generate infographics, audio summaries, and even combine them into a video."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!youtube-to-docs https://www.youtube.com/watch?v=atmGAHYpf_c \\\n",
+    "    -m gemini-2.0-flash \\\n",
+    "    --infographic gemini-2.0-flash \\\n",
+    "    --tts gemini-2.0-flash-tts \\\n",
+    "    --combine-infographic-audio"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Explore Results\n",
+    "\n",
+    "The results are saved in the `youtube-to-docs-artifacts` directory. You can browse them in the file explorer on the left."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls -R youtube-to-docs-artifacts"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This change adds a new 'Notebooks' section to the project. It includes a dedicated Google Colab notebook (`notebooks/getting_started.ipynb`) that demonstrates how to install and use the `youtube-to-docs` CLI. The documentation has been updated to include this new section in the MkDocs navigation and the README.

Fixes #16

---
*PR created automatically by Jules for task [5386323559298214048](https://jules.google.com/task/5386323559298214048) started by @raybellwaves*